### PR TITLE
Filled in descriptions and added attributes for credits to info.yml

### DIFF
--- a/contrib/tax_reform_viz_1/info.yml
+++ b/contrib/tax_reform_viz_1/info.yml
@@ -12,12 +12,21 @@ long_description: >
 	the tax system, the distribution of taxes across different income groups,
 	and the potential for rate reduction. Calculations do not include the
 	effect of tax reform on individuals' behavior or the economy as a whole.
-Concept_credit: Alex Brill and Matt Jensen
+Concept_credit: >
+	<a href = "https://www.aei.org/scholar/alex-brill/">Alex Brill</a> and
+	<a href = "https://www.aei.org/scholar/matthew-h-jensen/"Matt Jensen</a>
 Development_credit: >
-	T.J. Alumbaugh, Brendan Collins, and Sean Wang. 
+	<a href = "https://github.com/talumbau">T.J. Alumbaugh</a>,
+	<a href = "https://github.com/brendancol">Brendan Collins</a>, and
+	<a href = "https://github.com/GoFroggyRun">Sean Wang</a>.
 OSS_credit: >
-	Tax-Calculator and TaxData for tax computations. Bokeh for visualizations.
-	Bokeh for visualizations.  
+	<a href = "https://github.com/open-source-economics/tax-calculator">
+	Tax-Calculator</a> and
+	<a href = "https://github.com/open-source-economics/taxdata">TaxData</a>
+	for tax computations.
+	<a href = "http://bokeh.pydata.org/en/latest/">Bokeh</a>
+	for visualizations.
+ 
 best_width: "100%"
 best_height: 500px
 build_cmd: "python build.py"

--- a/contrib/tax_reform_viz_1/info.yml
+++ b/contrib/tax_reform_viz_1/info.yml
@@ -3,8 +3,21 @@ plot_name: Tax Reform Visualization 1
 plot_id: tax_reform_viz_1
 content: index.html
 thumbnail: thumbnail.png
-short_description: This plot shows a short amount of stuff
-long_description: This plot shows a long amount of stuff
+short_description: > 
+	Explore the impact of eliminating itemized deductions on the simplicity of
+	the tax system, the distribution of taxes across different income groups,
+	and the potential for rate reduction.
+long_description: >
+	Explore the impact of eliminating itemized deductions on the simplicity of
+	the tax system, the distribution of taxes across different income groups,
+	and the potential for rate reduction. Calculations do not include the
+	effect of tax reform on individuals' behavior or the economy as a whole.
+Concept_credit: Alex Brill and Matt Jensen
+Development_credit: >
+	T.J. Alumbaugh, Brendan Collins, and Sean Wang. 
+OSS_credit: >
+	Tax-Calculator and TaxData for tax computations. Bokeh for visualizations.
+	Bokeh for visualizations.  
 best_width: "100%"
 best_height: 500px
 build_cmd: "python build.py"


### PR DESCRIPTION
@brendancol and @talumbau, what do you think of these new credit attributes and the length/content of the descriptions? 

Based on @brendancol's suggestion https://github.com/open-source-economics/plots/issues/11#issuecomment-227289446 I am thinking we could pull the info from these attributes into the text that is displayed on the plot (long_description, concept credit, development_credit, OSS_credit, and a hosting credit for OSPC would be added to all plots in the gallery.) 

If we proceed this way, an outstanding question is how to store hyperlink information in info.yml. For instance, we would probably want links for the names of people and the names of key OSS projects. 
